### PR TITLE
Allow option for antch to set HTTP2ForceUpgrade transport param

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -47,6 +47,9 @@ type Crawler struct {
 	// UserAgent specifies the user-agent for the remote server.
 	UserAgent string
 
+	// ForceAttemptHTTP2 specifies the corresponding field in the underlying HTTP transport.
+	ForceAttemptHTTP2 bool
+
 	// ErrorLog specifies an optional logger for errors HTTP transports
 	// and unexpected behavior from handlers.
 	// If nil, logging goes to os.Stderr via the log package's
@@ -196,6 +199,7 @@ func (c *Crawler) transport() http.RoundTripper {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		DialContext:           proxyDialContext,
+		ForceAttemptHTTP2:     c.ForceAttemptHTTP2,
 	}
 
 	var stack HttpMessageHandler = HttpMessageHandlerFunc(func(req *http.Request) (*http.Response, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/neevaco/antch
+
+go 1.13
+
+require (
+	github.com/antchfx/htmlquery v0.0.0-20180726134113-496ad84c8a0c
+	github.com/antchfx/jsonquery v1.1.2
+	github.com/antchfx/xmlquery v0.0.0-20180726134140-2805f22c26c4
+	github.com/antchfx/xpath v0.0.0-20180524052354-077bca4d2caa
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/temoto/robotstxt v0.0.0-20170603013557-9e4646fa7053
+	github.com/tylertreat/BoomFilters v0.0.0-20180508140553-8298e22dd59a
+	golang.org/x/net v0.0.0-20180724234803-3673e40ba225
+	golang.org/x/text v0.3.1-0.20180708171225-0605a8320ace
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/antchfx/htmlquery v0.0.0-20180726134113-496ad84c8a0c h1:R2UJ6v/5Odwld2Fp6GMio7doZrgAfUiYVMbWoBnQ/Xw=
+github.com/antchfx/htmlquery v0.0.0-20180726134113-496ad84c8a0c/go.mod h1:MS9yksVSQXls00iXkiMqXr0J+umL/AmxXKuP28SUJM8=
+github.com/antchfx/jsonquery v1.1.2 h1:VbEEjyuV8soor2TfE86b7wLDzY5f1mMt1JTOmnHopTs=
+github.com/antchfx/jsonquery v1.1.2/go.mod h1:h7950pvPrUZzJIflNqsELgDQovTpPNa0rAHf8NwjegY=
+github.com/antchfx/xmlquery v0.0.0-20180726134140-2805f22c26c4 h1:ntzM+2QnQcuvKLqs/NoD31DKcrm+3JmmItM0jtqsnb0=
+github.com/antchfx/xmlquery v0.0.0-20180726134140-2805f22c26c4/go.mod h1:/+CnyD/DzHRnv2eRxrVbieRU/FIF6N0C+7oTtyUtCKk=
+github.com/antchfx/xpath v0.0.0-20180524052354-077bca4d2caa h1:UgmswLpr8R1msC4cA74MD6zt66QSQckaD5ph7XFyOfY=
+github.com/antchfx/xpath v0.0.0-20180524052354-077bca4d2caa/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/temoto/robotstxt v0.0.0-20170603013557-9e4646fa7053 h1:yZpEd8aMDR3WRe3x/04CUHieSuSPM18P3bhLxp2zels=
+github.com/temoto/robotstxt v0.0.0-20170603013557-9e4646fa7053/go.mod h1:aOux3gHPCftJ3KHq6Pz/AlDjYJ7Y+yKfm1gU/3B0u04=
+github.com/tylertreat/BoomFilters v0.0.0-20180508140553-8298e22dd59a/go.mod h1:OYRfF6eb5wY9VRFkXJH8FFBi3plw2v+giaIu7P054pM=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225 h1:kNX+jCowfMYzvlSvJu5pQWEmyWFrBXJ3PBy10xKMXK8=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.1-0.20180708171225-0605a8320ace h1:kyN0VIoCEmeNB+h2yOVcqeM89hfo8ePkt9PQNzaQNkQ=
+golang.org/x/text v0.3.1-0.20180708171225-0605a8320ace/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/robotstxt_test.go
+++ b/robotstxt_test.go
@@ -31,7 +31,7 @@ func TestRobotstxtHandler(t *testing.T) {
 	}{
 		{"/", "", true},
 		{"/shopping/", "", true},
-		{"account", "", false},
+		{"/account/", "", false},
 		{"/", "Twitterbot", false},
 	}
 


### PR DESCRIPTION
In follow up, I might propose to change crawler interface to allow a transport to be injected (or a http client). For now, this felt the minimal change to fix the bug where using a DialContext for HTTP Transport to use HTTP/2 